### PR TITLE
Dev

### DIFF
--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IBlock.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IBlock.kt
@@ -7,5 +7,5 @@ package dev.wuason.unearthMechanic.config
  * The interface is utilized to detect if an object is a block and to handle block-specific
  * interactions and events.
  */
-interface IBlock {
+interface IBlock: IGeneric {
 }

--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IBlockStage.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IBlockStage.kt
@@ -1,0 +1,4 @@
+package dev.wuason.unearthMechanic.config
+
+interface IBlockStage: IStage {
+}

--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IFurniture.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IFurniture.kt
@@ -7,5 +7,5 @@ package dev.wuason.unearthMechanic.config
  * and their associated functionality, such as handling player interactions
  * and furniture stages.
  */
-interface IFurniture {
+interface IFurniture: IGeneric {
 }

--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IFurnitureStage.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IFurnitureStage.kt
@@ -1,0 +1,4 @@
+package dev.wuason.unearthMechanic.config
+
+interface IFurnitureStage: IStage {
+}

--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IGeneric.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IGeneric.kt
@@ -70,4 +70,12 @@ interface IGeneric {
      * @return true if the instance is not protected, false otherwise.
      */
     fun isNotProtect(): Boolean
+
+    /**
+     * Retrieves the stage that precedes the provided current stage.
+     *
+     * @param currentStage The current stage from which to retrieve the preceding stage.
+     * @return The stage instance that precedes the current stage.
+     */
+    fun getBackStage(currentStage: IStage): IStage
 }

--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IGeneric.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/config/IGeneric.kt
@@ -20,11 +20,11 @@ interface IGeneric {
     fun getTools(): Set<ITool>
 
     /**
-     * Retrieves the identifier for the base item.
+     * Retrieves the base stage of the current instance.
      *
-     * @return the base item ID as a String.
+     * @return An instance of `IStage` representing the base stage.
      */
-    fun getBaseItemId(): String
+    fun getBaseStage(): IStage
 
     /**
      * Retrieves the list of stages associated with the current object.

--- a/api/src/main/kotlin/dev/wuason/unearthMechanic/utils/Utils.kt
+++ b/api/src/main/kotlin/dev/wuason/unearthMechanic/utils/Utils.kt
@@ -49,7 +49,7 @@ class Utils {
             for (stage in stageData.getStage() downTo 0) {
                 stageData.getGeneric().getStages()[stage].getItemId()?.let { return it }
             }
-            return stageData.getGeneric().getBaseItemId()
+            return stageData.getGeneric().getBaseStage().getItemId()!!
         }
 
         /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ val targetJavaVersion = 21
 allprojects {
 
     project.group = "dev.wuason"
-    project.version = "0.1.9e"
+    project.version = "0.1.9f"
 
     //apply kotlin jvm plugin
     apply(plugin = "kotlin")

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/CommandManager.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/CommandManager.kt
@@ -57,7 +57,7 @@ class CommandManager(private val core: UnearthMechanic) : ICommandManager {
                                 AdventureUtils.sendMessage(player, "<yellow>StageData Info:")
                                 AdventureUtils.sendMessage(player, "<yellow>Stage actual: <aqua>" + stageData.getStage())
                                 AdventureUtils.sendMessage(player, "<yellow>Generic id: <aqua>" + stageData.getGeneric().getId())
-                                AdventureUtils.sendMessage(player, "<yellow>BaseItem id: <aqua>" + stageData.getGeneric().getBaseItemId())
+                                AdventureUtils.sendMessage(player, "<yellow>BaseItem id: <aqua>" + stageData.getGeneric().getBaseStage().getItemId())
                                 AdventureUtils.sendMessage(player, "<yellow>Actual item id: <aqua>" + stageData.getActualItemId())
                                 AdventureUtils.sendMessage(player, "<yellow>Loc: <aqua>" + stageData.getLocation())
                             }),

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Block.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Block.kt
@@ -1,5 +1,5 @@
 package dev.wuason.unearthMechanic.config
 
-class Block(private val id: String, tools: Set<ITool>, private val baseItemId: String, private val stages: List<IStage>, notProtected: Boolean) : Generic(id, tools, baseItemId, stages, notProtected), IBlock {
+class Block(private val id: String, tools: Set<ITool>, private val baseStage: BlockStage, private val stages: List<IStage>, notProtected: Boolean) : Generic(id, tools, baseStage, stages, notProtected), IBlock {
 }
 

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/BlockStage.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/BlockStage.kt
@@ -1,0 +1,33 @@
+package dev.wuason.unearthMechanic.config
+
+class BlockStage(
+    stage: Int,
+    itemId: String?,
+    drops: List<Drop>,
+    remove: Boolean,
+    removeItemMainHand: Boolean,
+    durabilityToRemove: Int,
+    usagesIaToRemove: Int,
+    onlyOneDrop: Boolean,
+    reduceItemHand: Int,
+    items: List<Item>,
+    onlyOneItem: Boolean,
+    sounds: List<Sound>,
+    delay: Long,
+    toolAnimDelay: Boolean
+) : Stage(
+    stage,
+    itemId,
+    drops,
+    remove,
+    removeItemMainHand,
+    durabilityToRemove,
+    usagesIaToRemove,
+    onlyOneDrop,
+    reduceItemHand,
+    items,
+    onlyOneItem,
+    sounds,
+    delay,
+    toolAnimDelay
+), IBlockStage

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Furniture.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Furniture.kt
@@ -1,4 +1,4 @@
 package dev.wuason.unearthMechanic.config
 
-class Furniture(id: String, tools: Set<ITool>, baseItemId: String, stages: List<IStage>, notProtected: Boolean):
-    Generic(id, tools, baseItemId, stages, notProtected), IFurniture
+class Furniture(id: String, tools: Set<ITool>, baseStage: FurnitureStage, stages: List<IStage>, notProtected: Boolean):
+    Generic(id, tools, baseStage, stages, notProtected), IFurniture

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/FurnitureStage.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/FurnitureStage.kt
@@ -1,0 +1,21 @@
+package dev.wuason.unearthMechanic.config
+
+class FurnitureStage(
+    stage: Int,
+    itemId: String?,
+    drops: List<Drop>,
+    remove: Boolean,
+    removeItemMainHand: Boolean,
+    durabilityToRemove: Int,
+    usagesIaToRemove: Int,
+    onlyOneDrop: Boolean,
+    reduceItemHand: Int,
+    items: List<Item>,
+    onlyOneItem: Boolean,
+    sounds: List<Sound>,
+    delay: Long,
+    toolAnimDelay: Boolean
+) : Stage(
+    stage, itemId, drops, remove, removeItemMainHand, durabilityToRemove, usagesIaToRemove,
+    onlyOneDrop, reduceItemHand, items, onlyOneItem, sounds, delay, toolAnimDelay
+), IFurnitureStage

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Generic.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Generic.kt
@@ -49,4 +49,9 @@ open class Generic(private val id: String, private val tools: Set<ITool>, privat
     override fun isNotProtect(): Boolean {
         return notProtected
     }
+
+    override fun getBackStage(currentStage: IStage): IStage {
+        if (currentStage.getStage() <= 0) return baseStage
+        return stages[currentStage.getStage() - 1]
+    }
 }

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Generic.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Generic.kt
@@ -4,7 +4,7 @@ import org.bukkit.Location
 import org.bukkit.entity.Player
 import org.bukkit.event.Event
 
-open class Generic(private val id: String, private val tools: Set<ITool>, private val baseItemId: String, private val stages: List<IStage> = mutableListOf(), private val notProtected: Boolean): IGeneric {
+open class Generic(private val id: String, private val tools: Set<ITool>, private val baseStage: IStage, private val stages: List<IStage> = mutableListOf(), private val notProtected: Boolean): IGeneric {
 
     private val stagesItemsId: HashMap<String, IStage> = HashMap<String, IStage>()
 
@@ -22,8 +22,8 @@ open class Generic(private val id: String, private val tools: Set<ITool>, privat
         return tools
     }
 
-    override fun getBaseItemId(): String {
-        return baseItemId
+    override fun getBaseStage(): IStage {
+        return baseStage;
     }
 
     override fun getStages(): List<IStage> {

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Stage.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Stage.kt
@@ -86,6 +86,7 @@ open class Stage(
         if(drops.isEmpty()) return
         if (isOnlyOneDrop()) {
             drops[Random.nextInt(drops.size)].dropItem(loc, true)
+            return
         }
         drops.forEach { it.dropItem(loc, true) }
     }

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Stage.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/config/Stage.kt
@@ -18,7 +18,7 @@ import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.util.RayTraceResult
 import kotlin.random.Random
 
-class Stage(
+open class Stage(
     private val stage: Int, private val itemId: String?, private val drops: List<Drop>, private val remove: Boolean, private val removeItemMainHand: Boolean,
     private val durabilityToRemove: Int,
     private val usagesIaToRemove: Int, private val onlyOneDrop: Boolean,

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/StageManager.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/StageManager.kt
@@ -246,11 +246,14 @@ class StageManager(private val core: UnearthMechanic) : IStageManager {
                 e.printStackTrace()
             }
         }
-
         stage.getItemId()?.let {
-
             if (isSimilarCompatibility(it, compatibility)) {
+
+                if (!generic.getBackStage(stage).javaClass.isInstance(stage)) {
+                    compatibility.handleRemove(player, event, loc, toolUsed, generic, stage)
+                }
                 compatibility.handleStage(player, it, event, loc, toolUsed, generic, stage)
+
             } else {
                 val c: ICompatibility =
                     getCompatibilityByAdapterId(it) ?: throw NullPointerException("Compatibility not found for $it")
@@ -281,7 +284,7 @@ class StageManager(private val core: UnearthMechanic) : IStageManager {
     }
 
     override fun isSimilarCompatibility(adapterId: String, compatibility: ICompatibility): Boolean {
-        return adapterId.contains(compatibility.adapterId(), true)
+        return adapterId.substring(0, adapterId.indexOf(":")).equals(compatibility.adapterId(), true)
     }
 
     override fun getAnimator(): IAnimationManager {

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/MinecraftImpl.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/MinecraftImpl.kt
@@ -89,10 +89,10 @@ class MinecraftImpl(private val core: UnearthMechanic, private val stageManager:
         generic: IGeneric,
         stage: IStage
     ) {
-        if (generic is IBlock) {
+        if (stage is IBlockStage) {
             handleBlockStage(player, itemId, event, loc, toolUsed, generic, stage)
         }
-        else if (generic is IFurniture) {
+        else if (stage is IFurnitureStage) {
             handleFurnitureStage(player, itemId, event, loc, toolUsed, generic, stage)
         }
     }
@@ -105,11 +105,8 @@ class MinecraftImpl(private val core: UnearthMechanic, private val stageManager:
         generic: IGeneric,
         stage: IStage
     ) {
-        if (generic is IBlock) {
+        if (event is PlayerInteractEvent) {
             loc.block.type = Material.AIR
-        }
-        else if (generic is IFurniture) {
-            throw UnsupportedOperationException("Minecraft does not support furniture stages")
         }
     }
 
@@ -121,7 +118,7 @@ class MinecraftImpl(private val core: UnearthMechanic, private val stageManager:
         generic: IGeneric,
         stage: Int
     ): Int {
-        if (generic is IBlock && event is PlayerInteractEvent) {
+        if (event is PlayerInteractEvent) {
             val block: Block = event.clickedBlock!!
             return Utils.calculateHashCode(block.type.hashCode(), block.blockData.hashCode(), block.state.hashCode(), block.hashCode())
         }

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/ia/ItemsAdderImpl.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/ia/ItemsAdderImpl.kt
@@ -37,7 +37,7 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
 
     @EventHandler
     fun onInteractBlock(event: CustomBlockInteractEvent) {
-        if (event.action == Action.RIGHT_CLICK_BLOCK && event.player != null && event.hand == EquipmentSlot.HAND) {
+        if (event.action == Action.RIGHT_CLICK_BLOCK && event.hand == EquipmentSlot.HAND) {
             stageManager.interact(
                 event.player,
                 "ia:" + event.namespacedID,
@@ -50,7 +50,7 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
 
     @EventHandler
     fun onInteractFurniture(event: FurnitureInteractEvent) {
-        if (event.player != null && event.bukkitEntity != null) {
+        if (event.bukkitEntity != null) {
             stageManager.interact(
                 event.player,
                 "ia:" + event.namespacedID,
@@ -113,6 +113,9 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
         generic: IGeneric,
         stage: IStage
     ) {
+        if (stage is IBlockStage) {
+
+        }
         if (generic is IBlock) {
             handleBlockStage(player, itemId, event, loc, toolUsed, generic, stage)
         }
@@ -164,10 +167,10 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
         generic: IGeneric,
         stage: IStage
     ) {
-        if (generic is IBlock) {
+        if (stage is IBlockStage) {
             loc.block.type = org.bukkit.Material.AIR
         }
-        else if (generic is IFurniture) {
+        else if (stage is IFurnitureStage) {
             if (event is FurnitureInteractEvent) {
                 event.furniture?.remove(false)
             }

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/ia/ItemsAdderImpl.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/ia/ItemsAdderImpl.kt
@@ -75,7 +75,7 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
         CustomBlock.place(adapterId.replace("ia:", ""), location)
     }
 
-    private fun breakBlock(location: Location?, player: Player?) {
+    private fun breakBlock(location: Location?) {
         CustomBlock.remove(location)
     }
 
@@ -114,12 +114,9 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
         stage: IStage
     ) {
         if (stage is IBlockStage) {
-
-        }
-        if (generic is IBlock) {
             handleBlockStage(player, itemId, event, loc, toolUsed, generic, stage)
         }
-        else if (generic is IFurniture) {
+        else if (stage is IFurnitureStage) {
             handleFurnitureStage(player, itemId, event, loc, toolUsed, generic, stage)
         }
     }
@@ -157,6 +154,9 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
                 }
             }
         }
+        else {
+            CustomFurniture.spawn(itemId.replace("ia:", ""), loc.block)
+        }
     }
 
     override fun handleRemove(
@@ -167,13 +167,11 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
         generic: IGeneric,
         stage: IStage
     ) {
-        if (stage is IBlockStage) {
-            loc.block.type = org.bukkit.Material.AIR
+        if (event is CustomBlockInteractEvent) {
+            breakBlock(loc)
         }
-        else if (stage is IFurnitureStage) {
-            if (event is FurnitureInteractEvent) {
-                event.furniture?.remove(false)
-            }
+        if (event is FurnitureInteractEvent) {
+            event.furniture?.remove(false)
         }
     }
 
@@ -185,17 +183,13 @@ class ItemsAdderImpl(private val core: UnearthMechanic, private val stageManager
         generic: IGeneric,
         stage: Int
     ): Int {
-        if (generic is IBlock) {
-            if (event is CustomBlockInteractEvent) {
-                val block: Block = event.blockClicked
-                return Utils.calculateHashCode(block.location.hashCode(), block.hashCode(), block.type.hashCode(), block.blockData.hashCode(), block.state.hashCode())
-            }
+        if (event is CustomBlockInteractEvent) {
+            val block: Block = event.blockClicked
+            return Utils.calculateHashCode(block.location.hashCode(), block.hashCode(), block.type.hashCode(), block.blockData.hashCode(), block.state.hashCode())
         }
-        else if (generic is IFurniture) {
-            if (event is FurnitureInteractEvent) {
-                val entity: Entity = event.bukkitEntity
-                return Utils.calculateHashCode(entity.location.hashCode(), entity.hashCode(), entity.type.hashCode(), entity.uniqueId.hashCode(), entity.isDead.hashCode(), entity.facing.hashCode())
-            }
+        if (event is FurnitureInteractEvent) {
+            val entity: Entity = event.bukkitEntity
+            return Utils.calculateHashCode(entity.location.hashCode(), entity.hashCode(), entity.type.hashCode(), entity.uniqueId.hashCode(), entity.isDead.hashCode(), entity.facing.hashCode())
         }
         return -1
     }

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/or/OraxenImpl.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/or/OraxenImpl.kt
@@ -33,7 +33,7 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
 
     @EventHandler
     fun onInteractBlock(event: OraxenNoteBlockInteractEvent) {
-        if (event.player != null && event.hand == EquipmentSlot.HAND && event.action == Action.RIGHT_CLICK_BLOCK) {
+        if (event.hand == EquipmentSlot.HAND && event.action == Action.RIGHT_CLICK_BLOCK) {
             stageManager.interact(
                 event.player,
                 "or:" + event.mechanic.itemID,
@@ -46,7 +46,7 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
 
     @EventHandler
     fun onInteractBlock(event: OraxenStringBlockInteractEvent) {
-        if (event.player != null && event.hand == EquipmentSlot.HAND) {
+        if (event.hand == EquipmentSlot.HAND) {
             stageManager.interact(
                 event.player,
                 "or:" + event.mechanic.itemID,
@@ -59,7 +59,7 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
 
     @EventHandler
     fun onInteractFurniture(event: OraxenFurnitureInteractEvent) {
-        if (event.player != null && event.hand == EquipmentSlot.HAND) {
+        if (event.hand == EquipmentSlot.HAND) {
             stageManager.interact(
                 event.player,
                 "or:" + event.mechanic.itemID,

--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/or/OraxenImpl.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/compatibilities/or/OraxenImpl.kt
@@ -102,6 +102,12 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
     ) {
         OraxenFurniture.getFurnitureMechanic(adapterId.replace("or:", "")).place(location, yaw, blockFace)
     }
+    private fun placeFurniture(
+        adapterId: String,
+        location: Location,
+    ) {
+        OraxenFurniture.getFurnitureMechanic(adapterId.replace("or:", "")).place(location, 0f, BlockFace.UP)
+    }
 
     private fun breakFurniture(entity: Entity, player: Player, id: String) {
         OraxenFurniture.remove(entity, player, Drop(mutableListOf(), false, false, id))
@@ -132,9 +138,9 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
         generic: IGeneric,
         stage: IStage
     ) {
-        if (generic is IBlock) {
+        if (stage is IBlockStage) {
             handleBlockStage(player, itemId, event, loc, toolUsed, generic, stage)
-        } else if (generic is IFurniture) {
+        } else if (stage is IFurnitureStage) {
             handleFurnitureStage(player, itemId, event, loc, toolUsed, generic, stage)
         }
     }
@@ -163,6 +169,8 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
         if (event is OraxenFurnitureInteractEvent) {
             breakFurniture(event.baseEntity, player, event.mechanic.itemID)
             placeFurniture(itemId, loc, event.baseEntity.facing, event.baseEntity.location.yaw)
+        } else {
+            placeFurniture(itemId, loc)
         }
     }
 
@@ -174,12 +182,11 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
         generic: IGeneric,
         stage: IStage
     ) {
-        if (generic is IBlock) {
+        if (event is OraxenNoteBlockInteractEvent || event is OraxenStringBlockInteractEvent) {
             loc.block.type = org.bukkit.Material.AIR
-        } else if (generic is IFurniture) {
-            if (event is OraxenFurnitureInteractEvent) {
-                breakFurniture(event.baseEntity, player, event.mechanic.itemID)
-            }
+        }
+        if (event is OraxenFurnitureInteractEvent) {
+            breakFurniture(event.baseEntity, player, event.mechanic.itemID)
         }
     }
 
@@ -191,30 +198,28 @@ class OraxenImpl(private val core: UnearthMechanic, private val stageManager: St
         generic: IGeneric,
         stage: Int
     ): Int {
-        if (generic is IBlock) {
-            if (event is OraxenNoteBlockInteractEvent) {
-                val block: Block = event.block
-                return Utils.calculateHashCode(
-                    block.type.hashCode(),
-                    block.blockData.hashCode(),
-                    block.state.hashCode(),
-                    event.mechanic.itemID.hashCode(),
-                    block.hashCode()
-                )
-            }
-            if (event is OraxenStringBlockInteractEvent) {
-                val block: Block = event.block
-                return Utils.calculateHashCode(
-                    block.type.hashCode(),
-                    block.blockData.hashCode(),
-                    block.state.hashCode(),
-                    event.mechanic.itemID.hashCode(),
-                    block.hashCode()
-                )
-            }
+        if (event is OraxenNoteBlockInteractEvent) {
+            val block: Block = event.block
+            return Utils.calculateHashCode(
+                block.type.hashCode(),
+                block.blockData.hashCode(),
+                block.state.hashCode(),
+                event.mechanic.itemID.hashCode(),
+                block.hashCode()
+            )
+        }
+        if (event is OraxenStringBlockInteractEvent) {
+            val block: Block = event.block
+            return Utils.calculateHashCode(
+                block.type.hashCode(),
+                block.blockData.hashCode(),
+                block.state.hashCode(),
+                event.mechanic.itemID.hashCode(),
+                block.hashCode()
+            )
         }
 
-        if (generic is IFurniture && event is OraxenFurnitureInteractEvent) {
+        if (event is OraxenFurnitureInteractEvent) {
             val entity: Entity = event.baseEntity
             var result: Int = entity.type.hashCode()
             result = 31 * result + entity.isDead.hashCode()

--- a/core/src/main/resources/config1.yml
+++ b/core/src/main/resources/config1.yml
@@ -4,11 +4,8 @@ unearth:
     fish_destroyed1:
       base:
         - "ia:elitefantasy:fish_destroyed_sand_1;extension_1" #Item base
-
         - "ia:elitefantasy:fish_destroyed_sand_easd;extension_2" #Item base
-
         - "ia:elitefantasy:fish_destroyed_sand_fwe2;extension_3" #Item base
-
 
       tool:
         - ia:elitefantasy:big_brush;depth=1;deep=1;size=1
@@ -56,6 +53,15 @@ unearth:
             drops:
               - "ia:elitefantasy:fish_destroyed_1;1-64;55"
   furniture:
+    test_furniture:
+      base:
+        - "ia:elitefantasy:fish_destroyed_sand_1" #Item base
+      tool:
+        - "mc:air"
+      transformation:
+        stages:
+          1:
+            block_id: "ia:elitefantasy:fish_destroyed_sand_2"
     fish_destroyed:
       base:
         - "ia:elitefantasy:fish_destroyed_sand_1" #Item base

--- a/core/src/main/resources/config1.yml
+++ b/core/src/main/resources/config1.yml
@@ -1,7 +1,7 @@
 unearth:
   block:
-    no_protect: false #If true, the block will not be protected by the plugins compatibilities
     fish_destroyed1:
+      no_protect: false #If true, the block will not be protected by the plugins compatibilities
       base:
         - "ia:elitefantasy:fish_destroyed_sand_1;extension_1" #Item base
         - "ia:elitefantasy:fish_destroyed_sand_easd;extension_2" #Item base
@@ -62,6 +62,8 @@ unearth:
         stages:
           1:
             block_id: "ia:elitefantasy:fish_destroyed_sand_2"
+          2:
+            furniture_id: "ia:elitefantasy:fish_destroyed_sand_2"
     fish_destroyed:
       base:
         - "ia:elitefantasy:fish_destroyed_sand_1" #Item base


### PR DESCRIPTION
This pull request introduces significant changes to the `unearthMechanic` package, focusing on refactoring and enhancing the stage handling system. The most important changes include adding new interfaces and classes, modifying existing interfaces to extend new ones, and updating methods to use these new structures.

### Interface and Class Enhancements:

* [`api/src/main/kotlin/dev/wuason/unearthMechanic/config/IBlock.kt`](diffhunk://#diff-675c215e9e08a4a44844c7e3a9eefa5919b13f5bcb6f20bf6a425bf3ddadc756L10-R10): Modified the `IBlock` interface to extend `IGeneric`.
* [`api/src/main/kotlin/dev/wuason/unearthMechanic/config/IBlockStage.kt`](diffhunk://#diff-adaef0ea7909cacaf6a91ae2cbf5c2d7f8a4dd188c9d6132833bc320ce00d4aeR1-R4): Added a new `IBlockStage` interface extending `IStage`.
* [`api/src/main/kotlin/dev/wuason/unearthMechanic/config/IFurniture.kt`](diffhunk://#diff-327d16884d62660b012eceef940db711a88c7fe71801250a7d040fcee16aee53L10-R10): Modified the `IFurniture` interface to extend `IGeneric`.
* [`api/src/main/kotlin/dev/wuason/unearthMechanic/config/IFurnitureStage.kt`](diffhunk://#diff-62408d55cb517b6e5d109ea8fb12b2d5ee87092df2a51d94a4516db6486360e0R1-R4): Added a new `IFurnitureStage` interface extending `IStage`.

### Method and Functionality Updates:

* [`api/src/main/kotlin/dev/wuason/unearthMechanic/config/IGeneric.kt`](diffhunk://#diff-56ff5d039a2a31aad4824ee742b2b4056e3dc509bdf27aa8b1e9c887e1960264L23-R27): Updated methods to work with `IStage` instead of `String` for base stages. Added a new method `getBackStage` to retrieve the preceding stage. [[1]](diffhunk://#diff-56ff5d039a2a31aad4824ee742b2b4056e3dc509bdf27aa8b1e9c887e1960264L23-R27) [[2]](diffhunk://#diff-56ff5d039a2a31aad4824ee742b2b4056e3dc509bdf27aa8b1e9c887e1960264R73-R80)
* [`api/src/main/kotlin/dev/wuason/unearthMechanic/utils/Utils.kt`](diffhunk://#diff-a16f288fe2ceb1a1d58c24dcf55e129e9585f5bdb8d0a483f62588494d547bd1L52-R52): Changed the method to return the item ID from `getBaseStage` instead of `getBaseItemId`.
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/CommandManager.kt`](diffhunk://#diff-1fb981fd4f44e3c7d5cce0bf522ee1c93311d518c37428780c9bd2b5de23d652L60-R60): Updated command output to use `getBaseStage` for retrieving the base item ID.

### Refactoring for Stage Handling:

* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/Block.kt`](diffhunk://#diff-9246326b3052e5682bd03bdeae108b62ee3f97b3ac2bbdf8fdb68edde4a7a40aL3-R3): Refactored the `Block` class to use `BlockStage` instead of a base item ID.
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/BlockStage.kt`](diffhunk://#diff-de965fae9b8a0a03a1c67dc3400c21ba034719171e65f351f5cd6a6bf15ab899R1-R33): Added a new `BlockStage` class extending `Stage` and implementing `IBlockStage`.
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/ConfigManager.kt`](diffhunk://#diff-730841a02dabd27d6d438fb77febbb38278cb3c78aec3b78a41416fed27fb313R73-L74): Introduced `StageType` enum for handling different stage types and refactored the `ConfigManager` to use `StageType` and `baseStage`. [[1]](diffhunk://#diff-730841a02dabd27d6d438fb77febbb38278cb3c78aec3b78a41416fed27fb313R73-L74) [[2]](diffhunk://#diff-730841a02dabd27d6d438fb77febbb38278cb3c78aec3b78a41416fed27fb313L92) [[3]](diffhunk://#diff-730841a02dabd27d6d438fb77febbb38278cb3c78aec3b78a41416fed27fb313L102-R125) [[4]](diffhunk://#diff-730841a02dabd27d6d438fb77febbb38278cb3c78aec3b78a41416fed27fb313L133-R177) [[5]](diffhunk://#diff-730841a02dabd27d6d438fb77febbb38278cb3c78aec3b78a41416fed27fb313R241-R257)
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/Furniture.kt`](diffhunk://#diff-066f1dfb0f46c037fdf9c4fd6624cd064ee4f2c622b1dbab94087887491a14b5L3-R4): Refactored the `Furniture` class to use `FurnitureStage` instead of a base item ID.
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/FurnitureStage.kt`](diffhunk://#diff-18569e9f26db8dfe7b811cdc87afdfaa3158708dc00906618eac02b4da9463c4R1-R21): Added a new `FurnitureStage` class extending `Stage` and implementing `IFurnitureStage`.
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/Generic.kt`](diffhunk://#diff-c8135b68f97f165842223f8f98d8d4d228c78afc0b8d14010ad7dee2469b5fe1L7-R7): Updated the `Generic` class to use `baseStage` and added the `getBackStage` method. [[1]](diffhunk://#diff-c8135b68f97f165842223f8f98d8d4d228c78afc0b8d14010ad7dee2469b5fe1L7-R7) [[2]](diffhunk://#diff-c8135b68f97f165842223f8f98d8d4d228c78afc0b8d14010ad7dee2469b5fe1L25-R26) [[3]](diffhunk://#diff-c8135b68f97f165842223f8f98d8d4d228c78afc0b8d14010ad7dee2469b5fe1R52-R56)

### Miscellaneous Improvements:

* [`core/src/main/kotlin/dev/wuason/unearthMechanic/config/Stage.kt`](diffhunk://#diff-cd918f6cef4fd7caa8d83f256151d7c9da550f9516e50e2d36da91b195ebd70fL21-R21): Made the `Stage` class open and added a return statement in `dropItems` method. [[1]](diffhunk://#diff-cd918f6cef4fd7caa8d83f256151d7c9da550f9516e50e2d36da91b195ebd70fL21-R21) [[2]](diffhunk://#diff-cd918f6cef4fd7caa8d83f256151d7c9da550f9516e50e2d36da91b195ebd70fR89)
* [`core/src/main/kotlin/dev/wuason/unearthMechanic/system/StageManager.kt`](diffhunk://#diff-ccdb5f2a3013a62ba3f129a7839650bd6fa637e66ad6cbab3939797ae5a47968R68): Added a check for sneaking players and moved event cancellation to a more appropriate location. [[1]](diffhunk://#diff-ccdb5f2a3013a62ba3f129a7839650bd6fa637e66ad6cbab3939797ae5a47968R68) [[2]](diffhunk://#diff-ccdb5f2a3013a62ba3f129a7839650bd6fa637e66ad6cbab3939797ae5a47968L102-L104) [[3]](diffhunk://#diff-ccdb5f2a3013a62ba3f129a7839650bd6fa637e66ad6cbab3939797ae5a47968L139-L142) [[4]](diffhunk://#diff-ccdb5f2a3013a62ba3f129a7839650bd6fa637e66ad6cbab3939797ae5a47968R181-R183)