### PR TITLE
Update JavaDoc link in readme and automate version replacement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,6 +177,17 @@ tasks {
     build {
         dependsOn("shadowJar")
     }
+
 }
 
+gradle.projectsEvaluated {
+
+}
+val file = file("readme.md")
+gradle.projectsEvaluated {
+    val content = file.readText()
+    val newContent = content.replace(Regex("(?<=UnearthMechanic/)(.*?)(?=/javadoc)"), "${project.version}")
+    file.writeText(newContent)
+    println("Readme.md updated")
+}
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # -> JavaDoc below <-
 
-[here](https://jitpack.io/com/github/Wuason6x9/UnearthMechanic/0.1.9b/javadoc "Go to javadoc")
+[here](https://jitpack.io/com/github/Wuason6x9/UnearthMechanic/0.1.9f/javadoc "Go to javadoc")
 
 ## Use api
 


### PR DESCRIPTION
Updated the JavaDoc link in the readme to the latest version. Added a gradle task to automatically replace the version number in the readme file based on the project's version.