### PR TITLE
fix: require minimum amount specified in reduce_item_main_hand in main hand

### DIFF
--- a/core/src/main/kotlin/dev/wuason/unearthMechanic/system/StageManager.kt
+++ b/core/src/main/kotlin/dev/wuason/unearthMechanic/system/StageManager.kt
@@ -29,6 +29,7 @@ import dev.wuason.unearthMechanic.utils.Utils
 import dev.wuason.unearthMechanic.utils.Utils.Companion.toAdapter
 import org.bukkit.Bukkit
 import org.bukkit.FluidCollisionMode
+import org.bukkit.GameMode
 import org.bukkit.Location
 import org.bukkit.block.BlockFace
 import org.bukkit.entity.Player
@@ -321,6 +322,11 @@ class StageManager(private val core: UnearthMechanic) : IStageManager {
                 //Bukkit.getConsoleSender().sendMessage("El jugador tiene el permiso $permission y es $hasPermLuckPerms de Stage")
                 if (!hasPermLuckPerms) return
             }
+        }
+
+        if (stage.getReduceItemHand() > 0 && player.gameMode != GameMode.CREATIVE) {
+            val mainHand = toolUsed.getItemMainHand()
+            if (mainHand == null || mainHand.type.isAir || mainHand.amount < stage.getReduceItemHand()) return
         }
 
         if (activeSequences.contains(loc)) {


### PR DESCRIPTION
Prior to this pull request, the furniture shared below does not behave correctly because you could right click the crate_packer with only one apple and receive an apple crate.

`  furniture:
    crate_packer:
      base: "nexo:crate_packer"
      tool:
        - "mc:apple"
      transformation:
        stages:
          1:
            furniture_id: "nexo:crate_packer"
            reduce_item_main_hand: 9
            drops:
              - "nexo:apple_crate;1;100"`

This pull request fixes that behaviour by requiring the minimum amount of tool in your main hand according to reduce_item_main_hand. 

So with this PR in this case, unless you have 9 apples, the crate packer does not give you an apple crate.